### PR TITLE
Improve sanitization in params preparation

### DIFF
--- a/src/Rest/Routes/AbstractUtilsBaseRoute.php
+++ b/src/Rest/Routes/AbstractUtilsBaseRoute.php
@@ -190,8 +190,27 @@ abstract class AbstractUtilsBaseRoute extends AbstractRoute implements CallableR
 					return $innerNotEmpty[0];
 				}
 
-				// Just decode value.
-				return \json_decode(\sanitize_text_field($item), true);
+				// Try to clean the string.
+				// Parts of the code taken from https://developer.wordpress.org/reference/functions/_sanitize_text_fields/
+				$item = \wp_check_invalid_utf8($item);
+				$item = \wp_strip_all_tags($item);
+
+				$filtered = trim($item);
+
+				// Remove percent-encoded characters.
+				$found = false;
+				while (preg_match('/%[a-f0-9]{2}/i', $filtered, $match)) {
+					$filtered = str_replace($match[0], '', $filtered);
+					$found = true;
+				}
+
+				if ($found) {
+					// Strip out the whitespace that may now exist after removing percent-encoded characters.
+					$filtered = trim(preg_replace('/ +/', ' ', $filtered));
+				}
+
+				// Decode value.
+				return \json_decode($filtered, true);
 			},
 			$params
 		);

--- a/src/Rest/Routes/AbstractUtilsBaseRoute.php
+++ b/src/Rest/Routes/AbstractUtilsBaseRoute.php
@@ -191,22 +191,22 @@ abstract class AbstractUtilsBaseRoute extends AbstractRoute implements CallableR
 				}
 
 				// Try to clean the string.
-				// Parts of the code taken from https://developer.wordpress.org/reference/functions/_sanitize_text_fields/
+				// Parts of the code taken from https://developer.wordpress.org/reference/functions/_sanitize_text_fields/.
 				$item = \wp_check_invalid_utf8($item);
 				$item = \wp_strip_all_tags($item);
 
-				$filtered = trim($item);
+				$filtered = \trim($item);
 
 				// Remove percent-encoded characters.
 				$found = false;
-				while (preg_match('/%[a-f0-9]{2}/i', $filtered, $match)) {
-					$filtered = str_replace($match[0], '', $filtered);
+				while (\preg_match('/%[a-f0-9]{2}/i', $filtered, $match)) {
+					$filtered = \str_replace($match[0], '', $filtered);
 					$found = true;
 				}
 
 				if ($found) {
 					// Strip out the whitespace that may now exist after removing percent-encoded characters.
-					$filtered = trim(preg_replace('/ +/', ' ', $filtered));
+					$filtered = \trim(\preg_replace('/ +/', ' ', $filtered));
 				}
 
 				// Decode value.


### PR DESCRIPTION
# Description

`sanitize_text_field` can be too aggressive when saving settings (namely stripping `<` character).

I've used the code from that function, but without encoding `<` to `&lt;`.

@mbmjertan I'll need your help with this to see if it would be safe from any kind of SQL injections or other vulnerabilities that could be exploited using not encoding `<` character.